### PR TITLE
[ADS-8279] chore: use forked word-wrap package to resolve dependabot alert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2249,6 +2249,16 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/optionator/node_modules/word-wrap": {
+      "name": "@aashutoshrathi/word-wrap",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
+      "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -2833,15 +2843,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/wrappy": {
@@ -4460,7 +4461,15 @@
         "levn": "^0.4.1",
         "prelude-ls": "^1.2.1",
         "type-check": "^0.4.0",
-        "word-wrap": "^1.2.3"
+        "word-wrap": "npm:@aashutoshrathi/word-wrap@1.2.6"
+      },
+      "dependencies": {
+        "word-wrap": {
+          "version": "npm:@aashutoshrathi/word-wrap@1.2.6",
+          "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
+          "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
+          "peer": true
+        }
       }
     },
     "p-limit": {
@@ -4856,12 +4865,6 @@
         "has-tostringtag": "^1.0.0",
         "is-typed-array": "^1.1.10"
       }
-    },
-    "word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-      "peer": true
     },
     "wrappy": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "url": "https://github.com/Adslot/eslint-config-adslot/issues"
   },
   "homepage": "https://github.com/Adslot/eslint-config-adslot#readme",
+  "overrides": {
+    "word-wrap": "npm:@aashutoshrathi/word-wrap@1.2.6"
+  },
   "scripts": {
     "postversion": "git push -u origin $(git rev-parse --abbrev-ref HEAD) --follow-tags && npm publish && echo '…released.'",
     "preversion": "echo 'Releasing…' && npm ci",


### PR DESCRIPTION
Fixes: https://github.com/Adslot/eslint-config-adslot/security/dependabot/5