### PR TITLE
v1.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eslint-config-adslot",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-config-adslot",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^5.61.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-adslot",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "ESLint configuration for Adslot",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
### Changes

- [96fa1bbfd9efeadb89c3cdb2cedfb78b19ad4db2] chore: use forked word-wrap package to resolve dependabot alert
 
- [44f7d3eeb16d946ee1a1950d0aae387f326d2d7e] chore: npm audit fix for semver dependabot alert
 
- [b0cd2a5e5a7ff6e594ad382fbafa4d3329e6f4fc] fix(deps): update dependency eslint-plugin-jest to ^27.2.2
 
- [92f023c34cbe301b94ea07daf1dd1fba77496f8b] chore(deps): update dependency eslint to ^8.44.0
 
- [dc879c2c247377243be200f91d459e29d3aaad02] fix(deps): update typescript to ^5.60.1
 
- [06c237a4b6d4633b8e6a1db98a2b9fe200c7bca6] fix(deps): update typescript to ^5.61.0
 
- [704d0e109d3960d9c84a03bc05628aed535763f4] build(deps): bump semver from 6.3.0 to 6.3.1
 
	


	Bumps [semver](https://github.com/npm/node-semver) from 6.3.0 to 6.3.1.


	- [Release notes](https://github.com/npm/node-semver/releases)


	- [Changelog](https://github.com/npm/node-semver/blob/v6.3.1/CHANGELOG.md)


	- [Commits](https://github.com/npm/node-semver/compare/v6.3.0...v6.3.1)


	


	---


	updated-dependencies:


	- dependency-name: semver


	  dependency-type: indirect


	...


	


	Signed-off-by: dependabot[bot] <support@github.com>

- [40a6354323fad609871c97337f82a4c6f4c53fed] chore: remove unneeded word-wrap npm overrides
 
- [cec9a8dc2b494dbd74b28cbbaab88646debc9c62] build: release patch version 1.6.1
 

### Comparison
https://github.com/Adslot/eslint-config-adslot/compare/v1.6.0...v1.6.1