### PR TITLE
fix: add ignoreExternal to import/no-cycle rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -189,7 +189,7 @@ module.exports = [
         'error',
         { groups: [['builtin', 'external', 'internal']] },
       ],
-      'import/no-cycle': 'error',
+      'import/no-cycle': ['error', { ignoreExternal: true }],
       'import/no-unresolved': ['error', { commonjs: true }],
       'import/no-duplicates': 'error',
 


### PR DESCRIPTION
Add `ignoreExternal: true` to import/no-cycle rule for improved performance

https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-cycle.md